### PR TITLE
Add page description setting

### DIFF
--- a/assets/javascripts/discourse/templates/donate.hbs
+++ b/assets/javascripts/discourse/templates/donate.hbs
@@ -1,4 +1,7 @@
-<h1>{{i18n 'discourse_donations.title'}}</h1>
-<div style="padding-top: 60px;">
+<h1>{{i18n 'discourse_donations.title' site_name=siteSettings.title}}</h1>
+<div class="donations-page-description">
+  {{cook-text siteSettings.discourse_donations_page_description}}
+</div>
+<div class="donations-page-payment">
   {{stripe-card}}
 </div>

--- a/assets/stylesheets/discourse-donations.css
+++ b/assets/stylesheets/discourse-donations.css
@@ -1,7 +1,17 @@
 div.stripe-errors {
-    border: 1px solid #c33;
-    border-radius: 5px;
-    color: #600;
-    background-color: #fdd;
-    padding: 5px 10px;
+  border: 1px solid #c33;
+  border-radius: 5px;
+  color: #600;
+  background-color: #fdd;
+  padding: 5px 10px;
+}
+
+.donations-page-description {
+  max-width: 700px;
+  font-size: 1.1em;
+  line-height: 24px;
+}
+
+.donations-page-payment {
+  padding-top: 60px;
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -11,6 +11,8 @@ en:
     discourse_donations_billing_address: "Collect billing address"
     discourse_donations_reward_badge_name: "Grant this badge to user when a payment is successful"
     discourse_donations_reward_group_name: "Add the user to this group when a payment is successful"
+    discourse_donations_page_description: "Text to be added to /donate page. Markdown is supported."
+
   js:
     discourse_donations:
       title: Donate

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -32,3 +32,6 @@ plugins:
   discourse_donations_reward_group_name:
     client: false
     default: 'Donation'
+  discourse_donations_page_description:
+    client: true
+    default: ''


### PR DESCRIPTION
Adds a setting that lets you insert text and images into the donate page. Markdown is supported.

e.g.

<img width="719" alt="screen shot 2018-02-02 at 1 44 00 pm" src="https://user-images.githubusercontent.com/5931623/35718377-2f7aabe4-081f-11e8-9953-a9378eb88dbb.png">
