### PR TITLE
Save and reuse stripe customer id when user is present

### DIFF
--- a/app/controllers/discourse_donations/checkout_controller.rb
+++ b/app/controllers/discourse_donations/checkout_controller.rb
@@ -11,11 +11,10 @@ module DiscourseDonations
 
       output = { 'messages' => [], 'rewards' => [] }
       payment = DiscourseDonations::Stripe.new(secret_key, stripe_options)
+      user = current_user || nil
 
       begin
-        charge = payment.checkoutCharge(user_params[:stripeEmail],
-                                        user_params[:stripeToken],
-                                        user_params[:amount])
+        charge = payment.checkoutCharge(user, user_params[:stripeEmail], user_params[:stripeToken], user_params[:amount])
       rescue ::Stripe::CardError => e
         err = e.json_body[:error]
 
@@ -24,7 +23,7 @@ module DiscourseDonations
         output['messages'] << "Decline code: #{err[:decline_code]}" if err[:decline_code]
         output['messages'] << "Message: #{err[:message]}" if err[:message]
 
-        render(:json => output) and return
+        render(json: output) && (return)
       end
 
       if charge['paid']
@@ -33,11 +32,10 @@ module DiscourseDonations
         output['rewards'] << { type: :badge, name: badge_name } if badge_name
       end
 
-      render :json => output
+      render json: output
     end
 
     private
-
 
     def reward?(payment)
       payment.present? && payment.successful?
@@ -61,6 +59,7 @@ module DiscourseDonations
                     :stripeToken,
                     :stripeTokenType,
                     :stripeEmail,
+                    :stripeCustomerId,
                     :stripeBillingName,
                     :stripeBillingAddressLine1,
                     :stripeBillingAddressZip,
@@ -75,7 +74,6 @@ module DiscourseDonations
                     :stripeShippingAddressCity,
                     :stripeShippingAddressCountry,
                     :stripeShippingAddressCountryCode
-
       )
     end
 

--- a/assets/javascripts/discourse/components/stripe-card.js.es6
+++ b/assets/javascripts/discourse/components/stripe-card.js.es6
@@ -63,18 +63,18 @@ export default Ember.Component.extend({
           self.endTranscation();
         }
         else {
-
           let params = {
             stripeToken: data.token.id,
             amount: self.get('amount') * 100,
+            user_id: self.get('currentUser.id'),
             email: self.get('email'),
             username: self.get('username'),
             create_account: self.get('create_accounts')
           };
 
           if(!self.get('paymentSuccess')) {
-            ajax('/charges', { data: params, method: 'post' }).then(data => {
-              self.concatMessages(data.messages);
+            ajax('/charges', { data: params, method: 'post' }).then(d => {
+              self.concatMessages(d.messages);
               self.endTranscation();
             });
           }

--- a/plugin.rb
+++ b/plugin.rb
@@ -18,6 +18,16 @@ end
 
 after_initialize do
   load File.expand_path('../app/jobs/jobs.rb', __FILE__)
+
+  class ::User
+    def stripe_customer_id
+      if custom_fields['stripe_customer_id']
+        custom_fields['stripe_customer_id']
+      else
+        nil
+      end
+    end
+  end
 end
 
 Discourse::Application.routes.prepend do

--- a/spec/services/discourse_donations/stripe_spec.rb
+++ b/spec/services/discourse_donations/stripe_spec.rb
@@ -44,12 +44,10 @@ module DiscourseDonations
           description: stripe_options[:description],
           currency: stripe_options[:currency]
         ).returns(
-          {
-            paid: true,
-            outcome: { seller_message: 'yay!' }
-          }
+          paid: true,
+          outcome: { seller_message: 'yay!' }
         )
-        subject.charge(email, params[:stripeToken], params[:amount])
+        subject.charge(nil, email, params[:stripeToken], params[:amount])
       end
     end
 
@@ -62,14 +60,14 @@ module DiscourseDonations
       end
 
       it 'is successful' do
-        ::Stripe::Charge.expects(:create).with(charge_options).returns({paid: true})
-        subject.charge(email, params[:stripeToken], params[:amount])
+        ::Stripe::Charge.expects(:create).with(charge_options).returns(paid: true)
+        subject.charge(nil, email, params[:stripeToken], params[:amount])
         expect(subject).to be_successful
       end
 
       it 'is not successful' do
-        ::Stripe::Charge.expects(:create).with(charge_options).returns({paid: false})
-        subject.charge(email, params[:stripeToken], params[:amount])
+        ::Stripe::Charge.expects(:create).with(charge_options).returns(paid: false)
+        subject.charge(nil, email, params[:stripeToken], params[:amount])
         expect(subject).not_to be_successful
       end
     end


### PR DESCRIPTION
If the donor is signed into an account on your Discourse instance, their stripe customer id will be saved to a UserCustomField and will be reused if that same user donates again. This means that in Stripe all transactions by that user will appear in their Customer profile, e.g.

<img width="685" alt="screenshot at feb 02 16-10-32" src="https://user-images.githubusercontent.com/5931623/35723059-da39f184-0833-11e8-8f41-f646712f96b7.png">

I've also made some code formatting changes to start to bring this plugin into line with the Rubocop rules used by Discourse. 
 