### PR TITLE
Add custom amount input

### DIFF
--- a/assets/javascripts/discourse/templates/components/stripe-card.hbs
+++ b/assets/javascripts/discourse/templates/components/stripe-card.hbs
@@ -7,6 +7,12 @@
     </label>
     <div class="controls controls-dropdown">
       {{combo-box valueAttribute="value" content=donateAmounts value=amount}}
+      {{#if showCustomAmount}}
+        {{input type='number'
+                value=customAmountInput
+                class='custom-amount-input'
+                placeholder=(i18n 'discourse_donations.custom_amount_placeholder')}}
+      {{/if}}
     </div>
   </div>
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -25,6 +25,8 @@ en:
       title: Donate
       nav_item: Donate
       amount: Amount
+      custom_amount: "Custom Amount"
+      custom_amount_placeholder: "Enter a number"
       card: Credit or debit card
       submit: Make Payment
       submit_with_create_account: Make Payment and Create Account

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,3 +50,6 @@ plugins:
     default: '1|2|5|10|20|50'
     regex: "^[0-9\\|]+$"
     regex_error: "site_settings.errors.discourse_donations_amount_must_be_number"
+  discourse_donations_custom_amount:
+    client: true
+    default: false


### PR DESCRIPTION
Shows a custom amount input when the user selects 'Custom Amount' in the amount combo-box.

<img width="722" alt="screen shot 2018-02-02 at 8 54 34 pm" src="https://user-images.githubusercontent.com/5931623/35734210-4bf5f576-085b-11e8-9e19-ab98ef71c74c.png">

Includes a setting to show/hide the option.